### PR TITLE
Remove _id if not present

### DIFF
--- a/lib/importer.js
+++ b/lib/importer.js
@@ -55,9 +55,13 @@ Importer.prototype.import = function (data, cb) {
     if (self.options.transform) {
       record = self.options.transform(record) || record
     }
-
-    body.push({ index: { _index: self.options.index, _type: self.options.type, _id: record._id } })
-    delete record._id
+    
+    if (record._id) {
+      body.push({ index: { _index: self.options.index, _type: self.options.type, _id: record._id } })
+      delete record._id
+    } else {
+      body.push({ index: { _index: self.options.index, _type: self.options.type } })
+    }
     body.push(record)
   })
 


### PR DESCRIPTION
## Description
Elasticsearch 5.x complains (gives an error) if we pass an empty `_id`, so if the input doesn't have a populated `_id` field the import will fail.
If we remove this field from the import header, elasticsearch will auto-generate it normally!

## How to test

1- start an elasticsearch instance.
This docker command can help:
```
docker run -it --rm -p 9200:9200 -p 9300:9300 -p 5601:5601  -e ES_HEAP_SIZE="256m" -e ES_JAVA_OPTS="-Xms256m -Xmx256m" -e LOGSTASH_START=0 --name elk --security-opt seccomp=unconfined sebp/elk
```

2- run `elastic-import` with a csv file without the `_id` field
```
elastic-import example.csv localhost:9200 example type --csv -p --header-fields
```